### PR TITLE
feat: add `tach mcp` — a Model Context Protocol server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,47 @@ python/tach/cache/setup.py[L7]: Import 'tach.filesystem.find_project_config_root
 ...
 ```
 
+### AI agents (MCP server)
+
+Tach runs as a [Model Context Protocol](https://modelcontextprotocol.io/) server, so AI agents can inspect, lint, configure, and report on your project boundaries without shelling out to individual commands:
+
+```bash
+tach mcp
+```
+
+Configure your MCP client (Claude Code, Claude Desktop, Codex CLI, etc.):
+
+```json
+{
+  "mcpServers": {
+    "tach": {
+      "command": "tach",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+The server exposes nine compact, paginated tools (`tach_onboard`, `tach_lint`, `tach_configure`, `tach_imports`, `tach_report`, `tach_map`, `tach_graph`, `tach_modularity`, `tach_test`), plus resources and prompts. The full configuration surface — modules, dependencies, layers, visibility, public interfaces, deprecations — is writable through `tach_configure`, so agents can manage boundaries end to end.
+
+An [Agent Skill](https://agentskills.io) that teaches agents the efficient workflow ships at [`skills/tach/SKILL.md`](skills/tach/SKILL.md) — copy it into your agent's skills directory:
+
+```bash
+# Claude Code                          # Codex CLI
+cp -r skills/tach .claude/skills/      cp -r skills/tach ~/.agents/skills/
+```
+
+**Why MCP instead of letting the agent run the CLI?** Token cost. Benchmarked over a real MCP stdio session against a fresh Django clone (~2,900 Python files, 9,534 file-level dependency edges):
+
+| Query | MCP default response | Naive alternative | Savings |
+|---|---|---|---|
+| Dependency map | 5.8 KB (~1.4K tokens) | 520.7 KB full map (~130K tokens) | **90x** |
+| Project summary | 2.5 KB | 14.0 KB full config | 5.5x |
+| 386 lint diagnostics | 19.8 KB first page (5.2 KB at `limit=10`) | ~150 KB unpaginated | 8–29x |
+| Blast radius of editing one ORM file | 2.9 KB (2,078 affected files, paginated) | reading the full closure | — |
+
+Every default response is summary-first with digests, pagination, and `tach://` resource URIs for opt-in full payloads — the full dependency map alone would exceed most agent context budgets. See the [MCP docs](https://docs.gauge.sh/usage/commands#tach-mcp) for tools, resources, hooks, and client setup.
+
 Tach also supports:
 
 - [Public interfaces for modules](https://docs.gauge.sh/usage/interfaces/)

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -459,6 +459,64 @@ Use tach_test with base="main" and pytest_args=["-q"]. Report the
 exit code and stdout_tail/stderr_tail.
 ```
 
+### Agent skill
+
+Tach ships an [Agent Skill](https://agentskills.io) at
+[`skills/tach/SKILL.md`](https://github.com/gauge-sh/tach/blob/main/skills/tach/SKILL.md)
+that teaches agents the efficient workflow on top of the MCP server: onboard
+first, prefer compact/paginated modes, diagnose with `tach_report`/`tach_map`,
+fix code before loosening rules, and verify with `tach_lint` plus `tach_test`.
+
+`SKILL.md` is a cross-tool format supported by Claude Code, Codex CLI, and
+other agents. Install it by copying the skill directory into your agent's
+skills location:
+
+```bash
+# Claude Code (per project)
+mkdir -p .claude/skills && cp -r skills/tach .claude/skills/
+
+# Claude Code (personal, all projects)
+mkdir -p ~/.claude/skills && cp -r skills/tach ~/.claude/skills/
+
+# Codex CLI
+mkdir -p ~/.agents/skills && cp -r skills/tach ~/.agents/skills/
+```
+
+Once installed, the skill activates automatically when the agent works in a
+repository containing a `tach.toml`, or when asked to enforce or fix module
+boundaries.
+
+### Hooks
+
+For Claude Code, you can add a `PostToolUse` hook so that boundary violations
+introduced while an agent edits code are fed straight back to it, instead of
+surfacing later in CI. Add to your project's `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && output=$(tach check 2>&1) || { echo \"$output\" >&2; exit 2; }"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Exit code 2 returns the diagnostics to the agent as feedback, so it fixes the
+violation immediately.
+
+For agents and environments without hooks,
+`tach_configure action="install_pre_commit"` (or `tach install pre-commit`)
+provides the same guarantee at commit time.
+
 
 ## tach test
 

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -393,6 +393,8 @@ summary is 5.8 KB versus 520.7 KB for the full file-level map (90x, roughly
 full config view, a 386-diagnostic lint run pages at 19.8 KB (or 5.2 KB with
 `limit=10`) versus ~150 KB unpaginated, and the blast radius of editing one
 ORM file — 2,078 affected files — comes back as a 2.9 KB paginated delta.
+Full methodology and a reproducible driver script are in the
+[MCP benchmark](mcp-benchmark.md) page.
 
 - `tach_onboard` - start here. Returns Tach/MCP versions, install/use hints, resource URIs, configured state, compact project summary, and recommended next actions.
 - `tach_lint` - strong lint entrypoint. Runs boundary, public-interface, external dependency, and unused dependency checks with counts, paginated diagnostics, and focused next actions.

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -305,6 +305,160 @@ Example output with closure:
 
 The output includes the target file itself and all files that are either directly or indirectly required by it. In this example, if `src/core.py` imports `config.py` which in turn imports `constants.py`, all of these files will appear in the closure.
 
+## tach mcp
+
+Tach can run as a [Model Context Protocol](https://modelcontextprotocol.io/) server.
+This lets MCP-compatible agents inspect, check, edit, and report on Tach projects
+without shelling out to individual Tach commands.
+
+```
+usage: tach mcp [-h]
+
+Start the Model Context Protocol (MCP) server over stdio
+
+options:
+  -h, --help  show this help message and exit
+```
+
+The server uses stdio transport. Configure your MCP client to run:
+
+```bash
+tach mcp
+```
+
+If you are working from this repository checkout before installing Tach, use:
+
+```bash
+uv run tach mcp
+```
+
+### Client configuration examples
+
+For Claude Desktop or other clients using JSON MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "tach": {
+      "command": "tach",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+For a local development checkout:
+
+```json
+{
+  "mcpServers": {
+    "tach": {
+      "command": "uv",
+      "args": ["run", "tach", "mcp"],
+      "cwd": "/path/to/tach"
+    }
+  }
+}
+```
+
+For Codex CLI, add a stdio MCP server entry:
+
+```toml
+[mcp_servers.tach]
+command = "tach"
+args = ["mcp"]
+enabled = true
+```
+
+For a local development checkout:
+
+```toml
+[mcp_servers.tach]
+command = "uv"
+args = ["run", "tach", "mcp"]
+enabled = true
+```
+
+### Available tools
+
+The MCP server exposes nine practical tools rather than one tool per CLI command.
+Large modes return compact summaries by default and include resource URIs or
+explicit full/export modes for larger payloads.
+
+- `tach_onboard` - start here. Returns Tach/MCP versions, install/use hints, resource URIs, configured state, compact project summary, and recommended next actions.
+- `tach_lint` - strong lint entrypoint. Runs boundary, public-interface, external dependency, and unused dependency checks with counts, paginated diagnostics, and focused next actions.
+- `tach_configure` - create config, edit modules/dependencies, sync dependencies, or install the pre-commit hook through one controlled write tool.
+- `tach_imports` - inspect first-party or external imports Tach sees in one Python file.
+- `tach_report` - produce dependency, usage, and optional external dependency reports for a file or directory.
+- `tach_map` - inspect dependency maps, closures, changed files, and changed-file deltas.
+- `tach_graph` - generate a module graph as Mermaid or DOT, compact by default.
+- `tach_modularity` - generate or export the local Gauge modularity report.
+- `tach_test` - run pytest with Tach affected-test filtering and compact stdout/stderr tails.
+
+### Resources and prompts
+
+The server exposes these resources:
+
+- `tach://version` - Tach and MCP protocol version JSON.
+- `tach://project-config/{project_ref}` - full project configuration JSON.
+- `tach://project-summary/{project_ref}` - compact project summary JSON.
+- `tach://project-graph/{project_ref}` - project graph as Mermaid text.
+- `tach://dependency-map/{project_ref}?view=summary|full` - dependency map summary or full JSON.
+- `tach://modularity-report/{project_ref}?view=summary|full` - modularity report summary or full JSON.
+- `tach://delta/{project_ref}/{snapshot_or_ref}` - compact dependency delta JSON.
+
+It also exposes prompts for common agent workflows:
+
+- `diagnose_tach_boundaries` - investigate boundary violations and suggest focused fixes.
+- `plan_tach_modularization` - plan module, utility, dependency, and interface boundaries for a project.
+
+### Example workflows
+
+Inspect a project and check its boundaries:
+
+```text
+Use the tach MCP server. Call tach_onboard for this repository, then
+tach_lint. Summarize any errors by file and module. If dependency rules look
+stale, call tach_configure action="sync_dependencies".
+```
+
+Create a starter config for a small project:
+
+```text
+Use tach_configure action="create_config" with project_root=/path/to/project,
+source_roots=["src"], modules=["api", "services", "models"], and
+dependencies=[{"path": "api", "dependency": "services"},
+{"path": "services", "dependency": "models"}].
+```
+
+Find the dependency closure for one file:
+
+```text
+Use tach_map mode="closure" with direction="dependencies" and
+path="src/api/handler.py". Return the closure as a sorted list.
+```
+
+Generate a graph for documentation:
+
+```text
+Use tach_graph with format="mermaid" and include_full=true.
+Put the returned graph in a Markdown code block for review.
+```
+
+Find affected files without loading the full map:
+
+```text
+Use tach_map mode="delta" with changed=["src/api/handler.py"]. Return
+changed_files, affected_count, and affected.items.
+```
+
+Run affected tests through an agent:
+
+```text
+Use tach_test with base="main" and pytest_args=["-q"]. Report the
+exit code and stdout_tail/stderr_tail.
+```
+
 
 ## tach test
 

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -385,6 +385,15 @@ The MCP server exposes nine practical tools rather than one tool per CLI command
 Large modes return compact summaries by default and include resource URIs or
 explicit full/export modes for larger payloads.
 
+This design is what keeps agent context budgets intact on real codebases.
+Benchmarked over an MCP stdio session against a fresh Django clone
+(~2,900 Python files, 9,534 file-level dependency edges): the dependency map
+summary is 5.8 KB versus 520.7 KB for the full file-level map (90x, roughly
+1.4K versus 130K tokens), the project summary is 2.5 KB versus 14.0 KB for the
+full config view, a 386-diagnostic lint run pages at 19.8 KB (or 5.2 KB with
+`limit=10`) versus ~150 KB unpaginated, and the blast radius of editing one
+ORM file — 2,078 affected files — comes back as a 2.9 KB paginated delta.
+
 - `tach_onboard` - start here. Returns Tach/MCP versions, install/use hints, resource URIs, configured state, compact project summary, and recommended next actions.
 - `tach_lint` - strong lint entrypoint. Runs boundary, public-interface, external dependency, and unused dependency checks with counts, paginated diagnostics, and focused next actions.
 - `tach_configure` - one controlled write tool for the whole config surface: create config, edit modules/dependencies, set layers (`set_layers`, `set_module_layer`), set module visibility, add/remove public interfaces, deprecate dependencies during migrations, sync dependencies, or install the pre-commit hook.

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -387,7 +387,7 @@ explicit full/export modes for larger payloads.
 
 - `tach_onboard` - start here. Returns Tach/MCP versions, install/use hints, resource URIs, configured state, compact project summary, and recommended next actions.
 - `tach_lint` - strong lint entrypoint. Runs boundary, public-interface, external dependency, and unused dependency checks with counts, paginated diagnostics, and focused next actions.
-- `tach_configure` - create config, edit modules/dependencies, sync dependencies, or install the pre-commit hook through one controlled write tool.
+- `tach_configure` - one controlled write tool for the whole config surface: create config, edit modules/dependencies, set layers (`set_layers`, `set_module_layer`), set module visibility, add/remove public interfaces, deprecate dependencies during migrations, sync dependencies, or install the pre-commit hook.
 - `tach_imports` - inspect first-party or external imports Tach sees in one Python file.
 - `tach_report` - produce dependency, usage, and optional external dependency reports for a file or directory.
 - `tach_map` - inspect dependency maps, closures, changed files, and changed-file deltas.
@@ -429,6 +429,23 @@ Use tach_configure action="create_config" with project_root=/path/to/project,
 source_roots=["src"], modules=["api", "services", "models"], and
 dependencies=[{"path": "api", "dependency": "services"},
 {"path": "services", "dependency": "models"}].
+```
+
+Introduce layered architecture rules:
+
+```text
+Use tach_configure action="set_layers" with layers=["ui", "commands", "core"],
+then action="set_module_layer" per module. Re-run tach_lint to see which
+imports violate the layering.
+```
+
+Expose a public interface and deprecate a legacy edge:
+
+```text
+Use tach_configure action="add_interface" with interface_expose=["get_user",
+"UserDTO"] and interface_from=["accounts"]. Then
+action="deprecate_dependency" with path="billing", dependency="legacy_db" to
+warn on remaining usages while migrating.
 ```
 
 Find the dependency closure for one file:

--- a/docs/usage/mcp-benchmark.md
+++ b/docs/usage/mcp-benchmark.md
@@ -1,0 +1,123 @@
+# MCP Server Benchmark
+
+The [`tach mcp`](commands.md#tach-mcp) server returns compact, paginated
+summaries by default so that AI agents can work on large codebases without
+exhausting their context budgets. This page documents the benchmark behind the
+numbers quoted in the docs, and how to reproduce it.
+
+## Environment
+
+- Tach with the MCP server (this repository, editable install)
+- Target codebase: fresh shallow clone of [Django](https://github.com/django/django)
+  (~2,900 Python files; Tach resolved 2,126 first-party files and 9,534
+  file-level dependency edges across 14 declared modules)
+- Transport: real MCP stdio session using the official `mcp` Python client —
+  byte counts are the exact JSON content returned over the wire, not internal
+  estimates. Tokens are approximated as bytes/4.
+
+## Results
+
+| Call | Default response | Full-mode / naive alternative | Savings |
+|---|---|---|---|
+| `tach_map mode="summary"` | 5,760 B (~1.4K tokens) | `mode="full"`: 520,696 B (~130K tokens) | **90x** |
+| `tach_onboard` (summary) | 2,532 B | `view="full"`: 14,037 B | 5.5x |
+| `tach_lint` (386 diagnostics) | 19,812 B first page (`limit=50`); 5,249 B at `limit=10` | ~150 KB unpaginated; raw `tach check-external` CLI output: 40,198 B | 2–29x |
+| `tach_report` (one file) | 2,797 B (`report_bytes` reports true size; truncates at `max_bytes`) | unbounded report text | size-capped |
+| `tach_map mode="delta"` (one ORM file changed) | 2,931 B conveying **2,078 affected files** (paginated) | reading the full closure | — |
+| `tach_configure` write actions (`sync_dependencies`, `set_layers`, `set_module_layer`, `deprecate_dependency`) | 220–270 B each, < 0.6 s | — | — |
+
+`sync_dependencies` wrote 90 module-level edges across the 14 Django modules
+in 2.8 s end-to-end over MCP (CLI `tach sync` on the same checkout: 2.5 s).
+
+Semantics checks on the same run: deprecating a real synced edge
+(`django.forms` → `django.core`) moved `warning_count` from 0 to 13 (one per
+importing file) with `error_count` unchanged, and the full dependency map —
+the naive thing an agent might otherwise load — would by itself exceed most
+agent context windows.
+
+## Reproduce it
+
+Clone a large target and run the driver below with the `mcp` Python package
+installed (`pip install mcp`, already a Tach dependency):
+
+```bash
+git clone --depth 1 https://github.com/django/django.git /tmp/django-bench
+python bench_mcp.py /tmp/django-bench
+```
+
+```python
+# bench_mcp.py
+import asyncio
+import json
+import sys
+import time
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+ROOT = sys.argv[1]
+MODULES = [
+    "django.apps", "django.conf", "django.core", "django.db",
+    "django.dispatch", "django.forms", "django.http", "django.middleware",
+    "django.template", "django.templatetags", "django.test", "django.urls",
+    "django.utils", "django.views",
+]
+
+
+def size_of(result):
+    return len(json.dumps([c.model_dump() for c in result.content]).encode())
+
+
+async def call(session, tool, label, **args):
+    start = time.monotonic()
+    result = await session.call_tool(tool, args)
+    print(f"{label}: {size_of(result)} bytes, "
+          f"{time.monotonic() - start:.2f}s, isError={result.isError}")
+    return result.structuredContent
+
+
+async def main():
+    params = StdioServerParameters(command="tach", args=["mcp"], cwd=ROOT)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            await call(session, "tach_onboard", "onboard_unconfigured",
+                       project_root=ROOT)
+            await call(session, "tach_configure", "create_config",
+                       action="create_config", project_root=ROOT,
+                       source_roots=["."], modules=MODULES)
+            await call(session, "tach_configure", "sync",
+                       action="sync_dependencies", project_root=ROOT)
+            await call(session, "tach_onboard", "onboard_summary",
+                       project_root=ROOT)
+            await call(session, "tach_onboard", "onboard_full",
+                       project_root=ROOT, view="full")
+            await call(session, "tach_map", "map_summary",
+                       project_root=ROOT, mode="summary")
+            await call(session, "tach_map", "map_full",
+                       project_root=ROOT, mode="full")
+            await call(session, "tach_graph", "graph_preview",
+                       project_root=ROOT)
+            await call(session, "tach_lint", "lint_default",
+                       project_root=ROOT)
+            await call(session, "tach_lint", "lint_limit10",
+                       project_root=ROOT, limit=10)
+            await call(session, "tach_report", "report_default",
+                       project_root=ROOT, path="django/db/models/query.py")
+            await call(session, "tach_map", "delta_one_file",
+                       project_root=ROOT, mode="delta",
+                       changed=["django/db/models/query.py"])
+            await call(session, "tach_configure", "set_layers",
+                       action="set_layers", project_root=ROOT,
+                       layers=["interface", "application", "core"])
+            await call(session, "tach_configure", "deprecate",
+                       action="deprecate_dependency", project_root=ROOT,
+                       path="django.forms", dependency="django.core")
+            await call(session, "tach_lint", "lint_after_deprecate",
+                       project_root=ROOT)
+
+
+asyncio.run(main())
+```
+
+Numbers vary slightly with the Django revision cloned; the ratios are stable.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Getting Started: getting-started/getting-started.md
   - Usage:
     - Commands: usage/commands.md
+    - MCP Benchmark: usage/mcp-benchmark.md
     - Configuration: usage/configuration.md
     - Interfaces: usage/interfaces.md
     - Layers: usage/layers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
+    "mcp>=1.27.1",
     "pyyaml~=6.0",
     "tomli>=1.2.2",
     "tomli-w~=1.0",

--- a/python/tach/cli.py
+++ b/python/tach/cli.py
@@ -432,6 +432,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to the config file",
     )
+
+    ## tach mcp
+    subparsers.add_parser(
+        "mcp",
+        prog=f"{TOOL_NAME} mcp",
+        help="Start the Model Context Protocol (MCP) server",
+        description="Start the Model Context Protocol (MCP) server over stdio",
+    )
+
     ## tach init
     init_parser = subparsers.add_parser(
         "init",
@@ -1063,6 +1072,18 @@ def tach_server(
         sys.exit(1)
 
 
+def tach_mcp() -> None:
+    logger.info(
+        "tach mcp called",
+        extra={
+            "data": CallInfo(function="tach_mcp"),
+        },
+    )
+    from tach.mcp import run
+
+    run()
+
+
 def tach_map(
     project_config: ProjectConfig,
     project_root: Path,
@@ -1198,6 +1219,9 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
             print(f"{args.target} is not a valid installation target.")
             sys.exit(1)
         tach_install(project_root=project_root, target=install_target)
+        return
+    elif args.command == "mcp":
+        tach_mcp()
         return
     elif args.command == "map":
         tach_map(

--- a/python/tach/mcp/__init__.py
+++ b/python/tach/mcp/__init__.py
@@ -29,6 +29,8 @@ from tach.mcp.testing import tach_test
 __all__ = [
     "mcp",
     "MCP_PROTOCOL_VERSION",
+    "diagnose_tach_boundaries",
+    "plan_tach_modularization",
     "run",
     "tach_configure",
     "tach_graph",

--- a/python/tach/mcp/__init__.py
+++ b/python/tach/mcp/__init__.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from tach.mcp.configuration import tach_configure
+from tach.mcp.dependency_map import (  # noqa: F401
+    delta_resource,
+    dependency_map_resource,
+    dependency_map_view_resource,
+    tach_map,
+)
+from tach.mcp.imports import tach_imports
+from tach.mcp.linting import diagnose_tach_boundaries, tach_lint  # noqa: F401
+from tach.mcp.modularity import (  # noqa: F401
+    modularity_report_resource,
+    modularity_report_view_resource,
+    plan_tach_modularization,
+    tach_modularity,
+)
+from tach.mcp.module_graph import graph_resource, tach_graph  # noqa: F401
+from tach.mcp.onboarding import (  # noqa: F401
+    config_resource,
+    project_summary_resource,
+    tach_onboard,
+    version_resource,
+)
+from tach.mcp.reporting import tach_report
+from tach.mcp.server import MCP_PROTOCOL_VERSION, mcp, run
+from tach.mcp.testing import tach_test
+
+__all__ = [
+    "mcp",
+    "MCP_PROTOCOL_VERSION",
+    "run",
+    "tach_configure",
+    "tach_graph",
+    "tach_imports",
+    "tach_lint",
+    "tach_map",
+    "tach_modularity",
+    "tach_onboard",
+    "tach_report",
+    "tach_test",
+]

--- a/python/tach/mcp/configuration.py
+++ b/python/tach/mcp/configuration.py
@@ -36,6 +36,7 @@ def tach_configure(
     module_action: Literal["create", "delete", "mark_utility", "unmark_utility"]
     | None = None,
     dependency_action: Literal["add", "remove"] | None = None,
+    forbid_circular_dependencies: bool = False,
     force: bool = False,
     add_only: bool = False,
     include_config: bool = False,
@@ -52,7 +53,14 @@ def tach_configure(
             raise ValueError(
                 f"Config already exists at '{config_path}'. Pass force=true."
             )
-        config = save_config(root, source_roots, modules, utilities, dependencies)
+        config = save_config(
+            root,
+            source_roots,
+            modules,
+            utilities,
+            dependencies,
+            forbid_circular_dependencies=forbid_circular_dependencies,
+        )
         result = {
             "ok": True,
             "action": action,

--- a/python/tach/mcp/configuration.py
+++ b/python/tach/mcp/configuration.py
@@ -9,9 +9,12 @@ from tach.mcp.payloads import digest
 from tach.mcp.project import (
     DependencyRule,
     config_summary,
+    find_module_entry,
+    load_config_toml,
     project_config,
     resolve_project_root,
     save_config,
+    save_config_toml,
 )
 from tach.mcp.server import mcp
 from tach.parsing import dump_project_config_to_toml
@@ -25,6 +28,13 @@ def tach_configure(
         "edit_dependency",
         "sync_dependencies",
         "install_pre_commit",
+        "set_layers",
+        "set_module_layer",
+        "set_module_visibility",
+        "deprecate_dependency",
+        "undeprecate_dependency",
+        "add_interface",
+        "remove_interface",
     ],
     project_root: str,
     source_roots: list[str] | None = None,
@@ -37,11 +47,21 @@ def tach_configure(
     | None = None,
     dependency_action: Literal["add", "remove"] | None = None,
     forbid_circular_dependencies: bool = False,
+    layers: list[str] | None = None,
+    layers_explicit_depends_on: bool | None = None,
+    layer: str | None = None,
+    visibility: list[str] | None = None,
+    interface_expose: list[str] | None = None,
+    interface_from: list[str] | None = None,
+    interface_visibility: list[str] | None = None,
+    interface_data_types: Literal["all", "primitive"] | None = None,
+    interface_exclusive: bool = False,
     force: bool = False,
     add_only: bool = False,
     include_config: bool = False,
 ) -> dict[str, Any]:
-    """Create or edit Tach config, sync dependencies, or install pre-commit."""
+    """Create or edit Tach config: modules, dependencies, layers, visibility,
+    interfaces, deprecations, sync, or pre-commit install."""
     root = resolve_project_root(project_root)
     result: dict[str, Any]
 
@@ -112,6 +132,131 @@ def tach_configure(
             "changed": before != dump_project_config_to_toml(after_config),
             "project_root": str(root),
             "digest": digest(config_summary(after_config)),
+        }
+    elif action == "set_layers":
+        if layers is None:
+            raise ValueError("layers is required for set_layers.")
+        config_data = load_config_toml(root)
+        config_data["layers"] = layers
+        if layers_explicit_depends_on is not None:
+            config_data["layers_explicit_depends_on"] = layers_explicit_depends_on
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "layers": layers,
+        }
+    elif action == "set_module_layer":
+        if path is None or layer is None:
+            raise ValueError("path and layer are required for set_module_layer.")
+        config_data = load_config_toml(root)
+        entry = find_module_entry(config_data, path)
+        entry["layer"] = layer
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "path": path,
+            "layer": layer,
+        }
+    elif action == "set_module_visibility":
+        if path is None or visibility is None:
+            raise ValueError(
+                "path and visibility are required for set_module_visibility."
+            )
+        config_data = load_config_toml(root)
+        entry = find_module_entry(config_data, path)
+        entry["visibility"] = visibility
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "path": path,
+            "visibility": visibility,
+        }
+    elif action in {"deprecate_dependency", "undeprecate_dependency"}:
+        if path is None or dependency is None:
+            raise ValueError(f"path and dependency are required for {action}.")
+        config_data = load_config_toml(root)
+        entry = find_module_entry(config_data, path)
+        depends_on = entry.get("depends_on", [])
+        rewritten: list[Any] = []
+        found = False
+        for item in depends_on:
+            item_path = item if isinstance(item, str) else item.get("path")
+            if item_path != dependency:
+                rewritten.append(item)
+                continue
+            found = True
+            if action == "deprecate_dependency":
+                rewritten.append({"path": dependency, "deprecated": True})
+            else:
+                rewritten.append(dependency)
+        if not found:
+            raise ValueError(
+                f"Module '{path}' has no declared dependency on '{dependency}'."
+            )
+        entry["depends_on"] = rewritten
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "path": path,
+            "dependency": dependency,
+            "deprecated": action == "deprecate_dependency",
+        }
+    elif action == "add_interface":
+        if interface_expose is None or interface_from is None:
+            raise ValueError(
+                "interface_expose and interface_from are required for add_interface."
+            )
+        config_data = load_config_toml(root)
+        interface_data: dict[str, Any] = {
+            "expose": interface_expose,
+            "from": interface_from,
+        }
+        if interface_visibility is not None:
+            interface_data["visibility"] = interface_visibility
+        if interface_data_types is not None:
+            interface_data["data_types"] = interface_data_types
+        if interface_exclusive:
+            interface_data["exclusive"] = True
+        config_data.setdefault("interfaces", []).append(interface_data)
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "interface": interface_data,
+        }
+    elif action == "remove_interface":
+        if interface_expose is None or interface_from is None:
+            raise ValueError(
+                "interface_expose and interface_from are required for remove_interface."
+            )
+        config_data = load_config_toml(root)
+        interfaces = config_data.get("interfaces", [])
+        remaining = [
+            item
+            for item in interfaces
+            if not (
+                set(item.get("expose", [])) == set(interface_expose)
+                and set(item.get("from", [])) == set(interface_from)
+            )
+        ]
+        if len(remaining) == len(interfaces):
+            raise ValueError("No interface matches the given expose/from lists.")
+        config_data["interfaces"] = remaining
+        save_config_toml(root, config_data)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "removed": len(interfaces) - len(remaining),
         }
     else:
         installed, warning = install_pre_commit_hook(root)

--- a/python/tach/mcp/configuration.py
+++ b/python/tach/mcp/configuration.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from tach import extension
+from tach.filesystem import build_project_config_path
+from tach.filesystem import install_pre_commit as install_pre_commit_hook
+from tach.mcp.payloads import digest
+from tach.mcp.project import (
+    DependencyRule,
+    config_summary,
+    project_config,
+    resolve_project_root,
+    save_config,
+)
+from tach.mcp.server import mcp
+from tach.parsing import dump_project_config_to_toml
+
+
+@mcp.tool()
+def tach_configure(
+    action: Literal[
+        "create_config",
+        "edit_module",
+        "edit_dependency",
+        "sync_dependencies",
+        "install_pre_commit",
+    ],
+    project_root: str,
+    source_roots: list[str] | None = None,
+    modules: list[str] | None = None,
+    utilities: list[str] | None = None,
+    dependencies: list[DependencyRule] | None = None,
+    path: str | None = None,
+    dependency: str | None = None,
+    module_action: Literal["create", "delete", "mark_utility", "unmark_utility"]
+    | None = None,
+    dependency_action: Literal["add", "remove"] | None = None,
+    force: bool = False,
+    add_only: bool = False,
+    include_config: bool = False,
+) -> dict[str, Any]:
+    """Create or edit Tach config, sync dependencies, or install pre-commit."""
+    root = resolve_project_root(project_root)
+    result: dict[str, Any]
+
+    if action == "create_config":
+        if source_roots is None or modules is None:
+            raise ValueError("source_roots and modules are required for create_config.")
+        config_path = build_project_config_path(root)
+        if config_path.exists() and not force:
+            raise ValueError(
+                f"Config already exists at '{config_path}'. Pass force=true."
+            )
+        config = save_config(root, source_roots, modules, utilities, dependencies)
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "config_path": str(config_path),
+            "module_count": len(config.module_paths()),
+            "dependency_count": len(dependencies or []),
+        }
+    elif action == "edit_module":
+        if path is None or module_action is None:
+            raise ValueError("path and module_action are required for edit_module.")
+        config = project_config(root)
+        if module_action == "create":
+            config.create_module(path)
+        elif module_action == "delete":
+            config.delete_module(path)
+        elif module_action == "mark_utility":
+            config.mark_module_as_utility(path)
+        else:
+            config.unmark_module_as_utility(path)
+        config.save_edits()
+        result = {"ok": True, "action": action, "project_root": str(root), "path": path}
+    elif action == "edit_dependency":
+        if path is None or dependency is None or dependency_action is None:
+            raise ValueError(
+                "path, dependency, and dependency_action are required for edit_dependency."
+            )
+        config = project_config(root)
+        if dependency_action == "add":
+            config.add_dependency(path, dependency)
+        else:
+            config.remove_dependency(path, dependency)
+        config.save_edits()
+        result = {
+            "ok": True,
+            "action": action,
+            "project_root": str(root),
+            "path": path,
+            "dependency": dependency,
+        }
+    elif action == "sync_dependencies":
+        config = project_config(root)
+        before = dump_project_config_to_toml(config)
+        extension.sync_project(project_root=root, project_config=config, add=add_only)
+        after_config = project_config(root)
+        result = {
+            "ok": True,
+            "action": action,
+            "changed": before != dump_project_config_to_toml(after_config),
+            "project_root": str(root),
+            "digest": digest(config_summary(after_config)),
+        }
+    else:
+        installed, warning = install_pre_commit_hook(root)
+        result = {
+            "ok": installed,
+            "action": action,
+            "project_root": str(root),
+            "installed": installed,
+            "warning": warning,
+        }
+
+    if include_config and action != "install_pre_commit":
+        result["config"] = config_summary(project_config(root))
+    return result

--- a/python/tach/mcp/dependency_map.py
+++ b/python/tach/mcp/dependency_map.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Literal
+
+from tach import extension
+from tach.extension import Direction, ProjectConfig
+from tach.filesystem.git_ops import get_changed_files
+from tach.mcp.payloads import DEFAULT_LIMIT, digest, truncate_items
+from tach.mcp.project import (
+    missing_config_result,
+    project_ref,
+    project_root_from_ref,
+    rel_project_path,
+    resolve_project_path,
+    resolve_project_root,
+)
+from tach.mcp.server import mcp
+from tach.parsing import parse_project_config
+
+
+def dependency_map_data(
+    root: Path,
+    config: ProjectConfig,
+    direction: Literal["dependencies", "dependents"],
+) -> dict[str, list[str]]:
+    dep_map = extension.DependentMap(
+        root,
+        config,
+        Direction.Dependencies if direction == "dependencies" else Direction.Dependents,
+    )
+    with tempfile.NamedTemporaryFile("r+", suffix=".json") as temp_file:
+        dep_map.write_to_file(Path(temp_file.name))
+        temp_file.seek(0)
+        return json.load(temp_file)
+
+
+def dependency_map_summary(
+    data: dict[str, list[str]],
+    *,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    rows = [
+        {"path": path, "edge_count": len(edges)} for path, edges in sorted(data.items())
+    ]
+    page = truncate_items(rows, limit=limit, offset=offset)
+    return {
+        "file_count": len(data),
+        "edge_count": sum(len(edges) for edges in data.values()),
+        "digest": digest(data),
+        "entries": page,
+        "truncated": page["truncated"],
+        "next_offset": page["next_offset"],
+    }
+
+
+@mcp.tool()
+def tach_map(
+    project_root: str | None = None,
+    mode: Literal["summary", "full", "closure", "delta", "changed_files"] = "summary",
+    direction: Literal["dependencies", "dependents"] = "dependencies",
+    path: str | None = None,
+    changed: list[str] | None = None,
+    base: str = "main",
+    head: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Inspect dependency map, closure, changed files, or affected-file delta."""
+    root = resolve_project_root(project_root)
+    config = parse_project_config(root)
+    if config is None:
+        return missing_config_result(mode, root)
+
+    if mode == "changed_files":
+        files = [
+            str(file_path.relative_to(root))
+            for file_path in get_changed_files(root, head=head, base=base)
+        ]
+        files.sort()
+        page = truncate_items(files, limit=limit, offset=offset)
+        return {
+            "mode": mode,
+            "project_root": str(root),
+            "base": base,
+            "head": head,
+            "digest": digest(files),
+            "files": page,
+            "truncated": page["truncated"],
+            "next_offset": page["next_offset"],
+        }
+
+    ref = project_ref(root)
+    if mode == "closure":
+        if path is None:
+            return {
+                "ok": False,
+                "mode": mode,
+                "error": "path is required for closure mode.",
+            }
+        dep_map = extension.DependentMap(
+            root,
+            config,
+            Direction.Dependencies
+            if direction == "dependencies"
+            else Direction.Dependents,
+        )
+        rel_path = rel_project_path(root, path)
+        return {
+            "mode": mode,
+            "direction": direction,
+            "closure": {str(rel_path): sorted(dep_map.get_closure([rel_path]))},
+        }
+
+    if mode == "delta":
+        if changed is None:
+            changed_paths = get_changed_files(root, head=head, base=base)
+        else:
+            changed_paths = [resolve_project_path(root, item) for item in changed]
+        rel_changed = sorted({item.relative_to(root) for item in changed_paths})
+        dependents_data = dependency_map_data(root, config, "dependents")
+        seed_paths = [item for item in rel_changed if str(item) in dependents_data]
+        affected = {str(item) for item in rel_changed}
+        if seed_paths:
+            dependents_map = extension.DependentMap(root, config, Direction.Dependents)
+            affected.update(dependents_map.get_closure(seed_paths))
+        closure = sorted(affected)
+        page = truncate_items(closure, limit=limit, offset=offset)
+        snapshot = digest(
+            {
+                "base": base,
+                "head": head,
+                "changed": [str(item) for item in rel_changed],
+            }
+        )
+        return {
+            "mode": mode,
+            "project_root": str(root),
+            "base": base,
+            "head": head,
+            "changed_files": [str(item) for item in rel_changed],
+            "affected_count": len(closure),
+            "affected": page,
+            "digest": digest(closure),
+            "resource_uri": f"tach://delta/{ref}/{snapshot}",
+            "truncated": page["truncated"],
+            "next_offset": page["next_offset"],
+        }
+
+    data = dependency_map_data(root, config, direction)
+    if mode == "full":
+        return {
+            "mode": mode,
+            "direction": direction,
+            "digest": digest(data),
+            "resource_uri": f"tach://dependency-map/{ref}?view=full",
+            "map": data,
+        }
+    return {
+        "mode": mode,
+        "direction": direction,
+        "resource_uri": f"tach://dependency-map/{ref}?view=full",
+        **dependency_map_summary(data, limit=limit, offset=offset),
+    }
+
+
+@mcp.resource("tach://dependency-map/{project_ref}")
+def dependency_map_resource(project_ref: str) -> str:
+    """Expose Tach dependency map summary as a JSON resource."""
+    root = project_root_from_ref(project_ref)
+    return json.dumps(tach_map(project_root=str(root), mode="summary"), indent=2)
+
+
+@mcp.resource("tach://dependency-map/{project_ref}?view={view}")
+def dependency_map_view_resource(project_ref: str, view: str) -> str:
+    """Expose Tach dependency map as summary or full JSON resource."""
+    root = project_root_from_ref(project_ref)
+    selected = "full" if view == "full" else "summary"
+    return json.dumps(tach_map(project_root=str(root), mode=selected), indent=2)
+
+
+@mcp.resource("tach://delta/{project_ref}/{snapshot_or_ref}")
+def delta_resource(project_ref: str, snapshot_or_ref: str) -> str:
+    """Expose a compact dependency delta resource for a git base ref."""
+    root = project_root_from_ref(project_ref)
+    try:
+        payload = tach_map(project_root=str(root), mode="delta", base=snapshot_or_ref)
+    except Exception as exc:
+        payload = {"error": str(exc), "snapshot_or_ref": snapshot_or_ref}
+    return json.dumps(payload, indent=2)

--- a/python/tach/mcp/imports.py
+++ b/python/tach/mcp/imports.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tach import extension
+from tach.mcp.project import (
+    default_python_file,
+    missing_config_result,
+    resolve_project_path,
+    resolve_project_root,
+)
+from tach.mcp.server import mcp
+from tach.parsing import parse_project_config
+
+
+@mcp.tool()
+def tach_imports(
+    path: str | None = None,
+    project_root: str | None = None,
+    external: bool = False,
+) -> dict[str, Any]:
+    """Inspect first-party or external imports Tach sees in one Python file."""
+    root = resolve_project_root(project_root)
+    config = parse_project_config(root)
+    if config is None:
+        return missing_config_result("imports", root)
+    if path is None:
+        path = default_python_file(root, config)
+    if path is None:
+        return {
+            "ok": False,
+            "mode": "imports",
+            "error": "path is required, and no Python file was found under source_roots.",
+        }
+    target = resolve_project_path(root, path)
+    source_roots = [root / source_root for source_root in config.source_roots]
+    get_imports = (
+        extension.get_external_imports if external else extension.get_project_imports
+    )
+    found_imports = get_imports(
+        project_root=root,
+        source_roots=source_roots,
+        file_path=target,
+        project_config=config,
+    )
+    return {
+        "mode": "imports",
+        "file": str(target),
+        "external": external,
+        "imports": [
+            {"module_path": item.module_path, "line_number": item.line_number}
+            for item in found_imports
+        ],
+    }

--- a/python/tach/mcp/linting.py
+++ b/python/tach/mcp/linting.py
@@ -192,6 +192,9 @@ def tach_lint(
             "Use tach_report for failing files.",
             "Use tach_configure action='sync_dependencies' if unused or missing dependencies are stale.",
             "Use tach_map mode='delta' to scope changed-file impact before editing.",
+            "For violations that must stay temporarily, add a "
+            "'# tach-ignore(reason)' comment on the import line instead of "
+            "loosening rules.",
         ]
     return result
 

--- a/python/tach/mcp/linting.py
+++ b/python/tach/mcp/linting.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tach import extension
+from tach.check_external import check_external
+from tach.mcp.payloads import DEFAULT_LIMIT, truncate_items
+from tach.mcp.project import project_config, resolve_project_root
+from tach.mcp.server import mcp
+
+
+def diagnostics_to_data(diagnostics: list[Any]) -> list[dict[str, Any]]:
+    data: list[dict[str, Any]] = []
+    for diagnostic in diagnostics:
+        usage_module = (
+            diagnostic.usage_module() if hasattr(diagnostic, "usage_module") else None
+        )
+        definition_module = (
+            diagnostic.definition_module()
+            if hasattr(diagnostic, "definition_module")
+            else None
+        )
+        data.append(
+            {
+                "message": diagnostic.to_string(),
+                "severity": "error" if diagnostic.is_error() else "warning",
+                "kind": (
+                    "dependency"
+                    if diagnostic.is_dependency_error()
+                    else "interface"
+                    if diagnostic.is_interface_error()
+                    else "configuration"
+                    if diagnostic.is_configuration()
+                    else "code"
+                    if diagnostic.is_code()
+                    else "unknown"
+                ),
+                "deprecated": diagnostic.is_deprecated(),
+                "usage_module": usage_module,
+                "definition_module": definition_module,
+                "file": diagnostic.pyfile_path(),
+                "line": diagnostic.pyline_number(),
+            }
+        )
+    return data
+
+
+@mcp.tool()
+def tach_lint(
+    project_root: str | None = None,
+    checks: list[str] | str | None = None,
+    exact: bool = False,
+    dependencies: bool = True,
+    interfaces: bool = True,
+    exclude: list[str] | None = None,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Strong Tach lint: boundaries, public interfaces, external deps, and stale rules."""
+    root = resolve_project_root(project_root)
+    allowed_checks = {"boundaries", "external", "unused"}
+    if checks is None:
+        requested_checks = ["boundaries", "external", "unused"]
+    elif isinstance(checks, str):
+        requested_checks = [checks]
+    else:
+        requested_checks = checks
+    invalid_checks = [
+        check for check in requested_checks if check not in allowed_checks
+    ]
+    selected = [check for check in requested_checks if check in allowed_checks]
+    if not selected:
+        selected = ["boundaries", "external", "unused"]
+    config = project_config(root, exclude)
+    result: dict[str, Any] = {
+        "project_root": str(root),
+        "checks": selected,
+        "ignored_checks": invalid_checks,
+        "diagnostic_count": 0,
+        "error_count": 0,
+        "warning_count": 0,
+    }
+    ok = True
+
+    if "boundaries" in selected:
+        diagnostics = extension.check(
+            project_root=root,
+            project_config=config,
+            dependencies=dependencies,
+            interfaces=interfaces,
+        )
+        diagnostics_data = diagnostics_to_data(diagnostics)
+        page = truncate_items(diagnostics_data, limit=limit, offset=offset)
+        boundaries_ok = not any(diagnostic.is_error() for diagnostic in diagnostics)
+        result["boundaries"] = {
+            "ok": boundaries_ok,
+            "diagnostics": page,
+        }
+        result["diagnostic_count"] += len(diagnostics_data)
+        result["error_count"] += sum(
+            1 for diagnostic in diagnostics_data if diagnostic["severity"] == "error"
+        )
+        result["warning_count"] += sum(
+            1 for diagnostic in diagnostics_data if diagnostic["severity"] == "warning"
+        )
+        ok &= boundaries_ok
+
+    if "external" in selected:
+        diagnostics = check_external(project_root=root, project_config=config)
+        diagnostics_data = diagnostics_to_data(diagnostics)
+        page = truncate_items(diagnostics_data, limit=limit, offset=offset)
+        external_ok = not any(diagnostic.is_error() for diagnostic in diagnostics)
+        result["external"] = {
+            "ok": external_ok,
+            "diagnostics": page,
+        }
+        result["diagnostic_count"] += len(diagnostics_data)
+        result["error_count"] += sum(
+            1 for diagnostic in diagnostics_data if diagnostic["severity"] == "error"
+        )
+        result["warning_count"] += sum(
+            1 for diagnostic in diagnostics_data if diagnostic["severity"] == "warning"
+        )
+        ok &= external_ok
+
+    if "unused" in selected:
+        unused = (
+            extension.detect_unused_dependencies(root, config)
+            if exact or config.exact
+            else []
+        )
+        unused_rows = [
+            {
+                "path": item.path,
+                "dependencies": [dependency.path for dependency in item.dependencies],
+            }
+            for item in unused
+        ]
+        unused_ok = not unused
+        result["unused"] = {
+            "ok": unused_ok,
+            "exact_checked": bool(exact or config.exact),
+            "unused_dependencies": truncate_items(
+                unused_rows, limit=limit, offset=offset
+            ),
+        }
+        result["diagnostic_count"] += len(unused_rows)
+        result["error_count"] += len(unused_rows)
+        ok &= unused_ok
+
+    result["ok"] = ok
+    if not ok:
+        result["next_actions"] = [
+            "Use tach_report for failing files.",
+            "Use tach_configure action='sync_dependencies' if unused or missing dependencies are stale.",
+            "Use tach_map mode='delta' to scope changed-file impact before editing.",
+        ]
+    return result
+
+
+@mcp.prompt()
+def diagnose_tach_boundaries(project_root: str = ".") -> str:
+    """Prompt for investigating Tach boundary violations."""
+    return (
+        f"Inspect Tach project at {project_root}. Run tach_onboard, "
+        "tach_lint, tach_report for failing files, and tach_graph. "
+        "Explain root cause and propose minimal tach.toml or import changes."
+    )

--- a/python/tach/mcp/linting.py
+++ b/python/tach/mcp/linting.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from tach import extension
 from tach.check_external import check_external
+from tach.errors import TachCircularDependencyError, TachVisibilityError
 from tach.mcp.payloads import DEFAULT_LIMIT, truncate_items
 from tach.mcp.project import project_config, resolve_project_root
 from tach.mcp.server import mcp
@@ -83,12 +84,49 @@ def tach_lint(
     ok = True
 
     if "boundaries" in selected:
-        diagnostics = extension.check(
-            project_root=root,
-            project_config=config,
-            dependencies=dependencies,
-            interfaces=interfaces,
-        )
+        try:
+            diagnostics = extension.check(
+                project_root=root,
+                project_config=config,
+                dependencies=dependencies,
+                interfaces=interfaces,
+            )
+        except TachCircularDependencyError as exc:
+            result["boundaries"] = {
+                "ok": False,
+                "circular_dependencies": exc.dependencies,
+            }
+            result["diagnostic_count"] += 1
+            result["error_count"] += 1
+            result["ok"] = False
+            result["next_actions"] = [
+                "Break the cycle by removing one dependency edge listed in "
+                "boundaries.circular_dependencies (tach_configure "
+                "action='edit_dependency', dependency_action='remove').",
+                "Use tach_report on the modules in the cycle to see which "
+                "imports create each edge.",
+            ]
+            return result
+        except TachVisibilityError as exc:
+            result["boundaries"] = {
+                "ok": False,
+                "visibility_errors": [
+                    {
+                        "dependent_module": dependent,
+                        "dependency_module": dependency,
+                        "visibility": visibility,
+                    }
+                    for dependent, dependency, visibility in exc.visibility_errors
+                ],
+            }
+            result["diagnostic_count"] += len(exc.visibility_errors)
+            result["error_count"] += len(exc.visibility_errors)
+            result["ok"] = False
+            result["next_actions"] = [
+                "Adjust 'visibility' on the listed modules in tach.toml, or "
+                "remove the dependency edges that violate it.",
+            ]
+            return result
         diagnostics_data = diagnostics_to_data(diagnostics)
         page = truncate_items(diagnostics_data, limit=limit, offset=offset)
         boundaries_ok = not any(diagnostic.is_error() for diagnostic in diagnostics)

--- a/python/tach/mcp/modularity.py
+++ b/python/tach/mcp/modularity.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from contextlib import redirect_stdout
+from dataclasses import asdict
+from io import StringIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from tach.mcp.payloads import (
+    DEFAULT_LIMIT,
+    digest,
+    payload_size,
+    truncate_items,
+)
+from tach.mcp.project import (
+    missing_config_result,
+    project_ref,
+    project_root_from_ref,
+    resolve_project_root,
+)
+from tach.mcp.server import mcp
+from tach.modularity import export_report, generate_modularity_report
+from tach.parsing import parse_project_config
+
+if TYPE_CHECKING:
+    from tach.extension import ProjectConfig
+
+
+def modularity_report_payload(
+    root: Path, config: ProjectConfig, force: bool
+) -> dict[str, Any]:
+    with redirect_stdout(StringIO()):
+        return asdict(generate_modularity_report(root, config, force=force))
+
+
+def modularity_report_summary(
+    payload: dict[str, Any],
+    *,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    modules = payload.get("modules", [])
+    module_rows = [
+        {
+            "path": module.get("path"),
+            "dependency_count": len(module.get("depends_on", [])),
+            "has_interface": module.get("has_interface"),
+            "layer": module.get("layer"),
+        }
+        for module in modules
+    ]
+    return {
+        "repo": payload.get("repo"),
+        "module_count": len(modules),
+        "diagnostic_count": len(payload.get("diagnostics", [])),
+        "usage_count": len(payload.get("usages", [])),
+        "digest": digest(payload),
+        "bytes": payload_size(payload),
+        "modules": truncate_items(module_rows, limit=limit, offset=offset),
+    }
+
+
+@mcp.tool()
+def tach_modularity(
+    project_root: str | None = None,
+    mode: Literal["summary", "full", "export"] = "summary",
+    output_path: str | None = None,
+    force: bool = True,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Generate or export local Gauge modularity report."""
+    try:
+        root = resolve_project_root(project_root)
+        config = parse_project_config(root)
+        if config is None:
+            return missing_config_result(mode, root)
+
+        if mode == "export":
+            output = Path(output_path).expanduser().resolve() if output_path else None
+            with redirect_stdout(StringIO()):
+                export_report(root, config, output, force=force)
+            written_path = output or root / "modularity_report.json"
+            return {
+                "ok": True,
+                "mode": mode,
+                "output_path": str(written_path),
+                "bytes": written_path.stat().st_size,
+            }
+
+        payload = modularity_report_payload(root, config, force=force)
+        ref = project_ref(root)
+        if mode == "full":
+            return {
+                "mode": mode,
+                "digest": digest(payload),
+                "resource_uri": f"tach://modularity-report/{ref}?view=full",
+                **payload,
+            }
+        return {
+            "mode": mode,
+            "resource_uri": f"tach://modularity-report/{ref}?view=full",
+            **modularity_report_summary(payload, limit=limit, offset=offset),
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "mode": mode,
+            "error": str(exc),
+            "next_action": "Retry with force=true or use tach_lint/tach_map for local-only analysis.",
+        }
+
+
+@mcp.resource("tach://modularity-report/{project_ref}")
+def modularity_report_resource(project_ref: str) -> str:
+    """Expose Tach modularity report summary as a JSON resource."""
+    root = project_root_from_ref(project_ref)
+    return json.dumps(tach_modularity(project_root=str(root), mode="summary"), indent=2)
+
+
+@mcp.resource("tach://modularity-report/{project_ref}?view={view}")
+def modularity_report_view_resource(project_ref: str, view: str) -> str:
+    """Expose Tach modularity report as summary or full JSON resource."""
+    root = project_root_from_ref(project_ref)
+    selected = "full" if view == "full" else "summary"
+    return json.dumps(tach_modularity(project_root=str(root), mode=selected), indent=2)
+
+
+@mcp.prompt()
+def plan_tach_modularization(project_root: str = ".") -> str:
+    """Prompt for planning module-boundary adoption or cleanup."""
+    return (
+        f"Analyze Tach config at {project_root}. Use tach_onboard, "
+        "tach_map mode='summary' or mode='delta', and tach_lint. "
+        "Recommend source roots, modules, dependencies, utilities, and interface "
+        "boundaries."
+    )

--- a/python/tach/mcp/module_graph.py
+++ b/python/tach/mcp/module_graph.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from tach.mcp.payloads import DEFAULT_MAX_BYTES, digest, tail_text
+from tach.mcp.project import (
+    missing_config_result,
+    project_ref,
+    project_root_from_ref,
+    resolve_project_root,
+)
+from tach.mcp.server import mcp
+from tach.parsing import parse_project_config
+from tach.show import (
+    generate_module_graph_dot_string,
+    generate_module_graph_mermaid_string,
+)
+
+
+@mcp.tool()
+def tach_graph(
+    project_root: str | None = None,
+    format: Literal["mermaid", "dot"] = "mermaid",
+    included_paths: list[str] | None = None,
+    include_full: bool = False,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> dict[str, Any]:
+    """Generate compact module graph summary; pass include_full=true for graph text."""
+    root = resolve_project_root(project_root)
+    config = parse_project_config(root)
+    if config is None:
+        return missing_config_result("graph", root)
+    paths = [root / Path(path_item) for path_item in included_paths or []]
+    if format == "dot":
+        graph_text = generate_module_graph_dot_string(config, paths)
+    else:
+        graph_text = generate_module_graph_mermaid_string(config, paths)
+    ref = project_ref(root)
+    tail = tail_text(graph_text, max_bytes=max_bytes)
+    result = {
+        "mode": "graph",
+        "format": format,
+        "bytes": len(graph_text.encode()),
+        "digest": digest(graph_text),
+        "resource_uri": f"tach://project-graph/{ref}",
+        "truncated": tail["truncated"],
+    }
+    if include_full:
+        result["graph"] = graph_text
+    else:
+        result["graph_preview"] = tail["text"]
+    return result
+
+
+@mcp.resource("tach://project-graph/{project_ref}")
+def graph_resource(project_ref: str) -> str:
+    """Expose Tach project graph as a Mermaid resource."""
+    root = project_root_from_ref(project_ref)
+    return tach_graph(project_root=str(root), format="mermaid", include_full=True)[
+        "graph"
+    ]

--- a/python/tach/mcp/onboarding.py
+++ b/python/tach/mcp/onboarding.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from tach import __version__
+from tach.mcp.payloads import DEFAULT_LIMIT, digest
+from tach.mcp.project import (
+    compact_config_summary,
+    config_summary,
+    project_root_from_ref,
+    resolve_project_root,
+    resource_uris,
+)
+from tach.mcp.server import MCP_PROTOCOL_VERSION, mcp
+from tach.parsing import parse_project_config
+
+
+@mcp.tool()
+def tach_onboard(
+    project_root: str | None = None,
+    intent: Literal["discover", "bootstrap", "operate"] = "discover",
+    view: Literal["summary", "full"] = "summary",
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Start here: versions, install/use hints, resources, and optional config summary."""
+    root = resolve_project_root(project_root)
+    config = parse_project_config(root)
+    result: dict[str, Any] = {
+        "tach": __version__,
+        "mcp_protocol": MCP_PROTOCOL_VERSION,
+        "project_root": str(root),
+        "intent": intent,
+        "resources": resource_uris(root),
+        "tools": {
+            "tach_onboard": "discover project state and next actions",
+            "tach_configure": "create/edit/sync Tach config or install pre-commit",
+            "tach_lint": "run boundary/interface/external/unused dependency lint",
+            "tach_imports": "inspect imports for one file",
+            "tach_report": "generate dependency/usage/external reports",
+            "tach_map": "dependency map, closure, changed files, or delta",
+            "tach_graph": "module graph as Mermaid or DOT",
+            "tach_modularity": "local Gauge modularity report summary/full/export",
+            "tach_test": "run affected tests",
+        },
+        "client_command": "tach mcp",
+    }
+    if config is None:
+        result["configured"] = False
+        result["next_actions"] = [
+            "Call tach_configure action='create_config' with source_roots and modules.",
+            "Then call tach_configure action='sync_dependencies'.",
+            "Then call tach_lint.",
+        ]
+        return result
+
+    result["configured"] = True
+    if view == "full":
+        full = config_summary(config)
+        result["project"] = {"view": "full", "digest": digest(full), **full}
+    else:
+        result["project"] = {
+            "view": "summary",
+            **compact_config_summary(root, config, limit=limit, offset=offset),
+        }
+    if intent == "bootstrap":
+        result["next_actions"] = [
+            "Call tach_lint to verify boundaries, external imports, and stale dependency rules.",
+            "Call tach_map mode='delta' for changed files before large reviews.",
+            "Call tach_test after boundary checks pass.",
+        ]
+    return result
+
+
+@mcp.resource("tach://version")
+def version_resource() -> str:
+    """Expose Tach and MCP protocol version as a resource."""
+    return json.dumps(tach_onboard(), indent=2)
+
+
+@mcp.resource("tach://project-config/{project_ref}")
+def config_resource(project_ref: str) -> str:
+    """Expose full Tach project config as a JSON resource."""
+    root = project_root_from_ref(project_ref)
+    return json.dumps(tach_onboard(str(root), view="full")["project"], indent=2)
+
+
+@mcp.resource("tach://project-summary/{project_ref}")
+def project_summary_resource(project_ref: str) -> str:
+    """Expose compact Tach project summary as a JSON resource."""
+    root = project_root_from_ref(project_ref)
+    return json.dumps(tach_onboard(str(root))["project"], indent=2)

--- a/python/tach/mcp/payloads.py
+++ b/python/tach/mcp/payloads.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Any
+
+DEFAULT_LIMIT = 50
+DEFAULT_MAX_BYTES = 12_000
+
+
+def digest(data: Any) -> str:
+    payload = json.dumps(data, sort_keys=True, default=str, separators=(",", ":"))
+    return sha256(payload.encode()).hexdigest()[:16]
+
+
+def payload_size(data: Any) -> int:
+    return len(json.dumps(data, default=str, separators=(",", ":")).encode())
+
+
+def truncate_items(
+    items: list[Any],
+    *,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    limit = max(0, limit)
+    offset = max(0, offset)
+    end = offset + limit
+    return {
+        "items": items[offset:end],
+        "count": len(items),
+        "offset": offset,
+        "limit": limit,
+        "truncated": end < len(items),
+        "next_offset": end if end < len(items) else None,
+    }
+
+
+def tail_text(text: str, max_bytes: int = DEFAULT_MAX_BYTES) -> dict[str, Any]:
+    max_bytes = max(0, max_bytes)
+    encoded = text.encode()
+    if len(encoded) <= max_bytes:
+        return {"text": text, "bytes": len(encoded), "truncated": False}
+    tail = encoded[-max_bytes:].decode(errors="replace")
+    return {"text": tail, "bytes": len(encoded), "truncated": True}

--- a/python/tach/mcp/project.py
+++ b/python/tach/mcp/project.py
@@ -5,6 +5,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import tomli
 import tomli_w
 
 from tach.filesystem import build_project_config_path, find_project_config_root
@@ -145,6 +146,71 @@ def compact_config_summary(
     }
 
 
+def load_config_toml(root: Path) -> dict[str, Any]:
+    config_path = build_project_config_path(root)
+    if not config_path.exists():
+        raise ValueError(
+            f"No editable 'tach.toml' found at '{config_path}'. Config embedded "
+            "in pyproject.toml must be edited as a file."
+        )
+    with config_path.open("rb") as config_file:
+        return tomli.load(config_file)
+
+
+def _reordered_for_toml(data: dict[str, Any]) -> dict[str, Any]:
+    # tomli_w writes keys in dict order; a top-level scalar emitted after an
+    # array of tables would attach to the last table, so order them first.
+    def is_array_of_tables(value: Any) -> bool:
+        return (
+            isinstance(value, list)
+            and bool(value)
+            and all(isinstance(item, dict) for item in value)
+        )
+
+    simple = {
+        key: value for key, value in data.items() if not is_array_of_tables(value)
+    }
+    tables = {key: value for key, value in data.items() if is_array_of_tables(value)}
+    return {**simple, **tables}
+
+
+def _dumps_tach_toml(config_data: dict[str, Any]) -> str:
+    # Emit modules/interfaces as [[...]] arrays of tables. tomli_w writes
+    # lists of dicts as inline `modules = [{...}]` arrays, which the Rust
+    # config editor (sync_project, add_dependency, save_edits) silently
+    # fails to match and no-ops on.
+    data = _reordered_for_toml(config_data)
+    modules = data.pop("modules", [])
+    interfaces = data.pop("interfaces", [])
+    parts = [tomli_w.dumps(data)] if data else []
+    parts.extend("[[modules]]\n" + tomli_w.dumps(module) for module in modules)
+    parts.extend(
+        "[[interfaces]]\n" + tomli_w.dumps(interface) for interface in interfaces
+    )
+    return "\n".join(parts)
+
+
+def save_config_toml(root: Path, config_data: dict[str, Any]) -> ProjectConfig:
+    config_path = build_project_config_path(root)
+    config_path.write_text(_dumps_tach_toml(config_data))
+    config = parse_project_config(root)
+    if config is None:
+        raise ValueError(f"Failed to parse edited config at '{config_path}'.")
+    return config
+
+
+def find_module_entry(config_data: dict[str, Any], path: str) -> dict[str, Any]:
+    for entry in config_data.get("modules", []):
+        if entry.get("path") == path:
+            return entry
+        if path in entry.get("paths", []):
+            raise ValueError(
+                f"Module '{path}' is declared in a grouped 'paths' entry; "
+                "split it into its own [[modules]] entry in tach.toml first."
+            )
+    raise ValueError(f"Module '{path}' not found in config.")
+
+
 def save_config(
     root: Path,
     source_roots: list[str],
@@ -174,7 +240,7 @@ def save_config(
     if forbid_circular_dependencies:
         config_data["forbid_circular_dependencies"] = True
     config_data["modules"] = module_data
-    config_path.write_text(tomli_w.dumps(config_data))
+    config_path.write_text(_dumps_tach_toml(config_data))
     config = parse_project_config(root)
     if config is None:
         raise ValueError(f"Failed to parse new config at '{config_path}'.")

--- a/python/tach/mcp/project.py
+++ b/python/tach/mcp/project.py
@@ -151,6 +151,8 @@ def save_config(
     modules: list[str],
     utilities: list[str] | None = None,
     dependencies: list[DependencyRule] | None = None,
+    *,
+    forbid_circular_dependencies: bool = False,
 ) -> ProjectConfig:
     config_path = build_project_config_path(root)
     module_data: list[dict[str, Any]] = [
@@ -168,9 +170,11 @@ def save_config(
             item for item in module_data if item["path"] == dependency["path"]
         )
         module["depends_on"].append({"path": dependency["dependency"]})
-    config_path.write_text(
-        tomli_w.dumps({"source_roots": source_roots, "modules": module_data})
-    )
+    config_data: dict[str, Any] = {"source_roots": source_roots}
+    if forbid_circular_dependencies:
+        config_data["forbid_circular_dependencies"] = True
+    config_data["modules"] = module_data
+    config_path.write_text(tomli_w.dumps(config_data))
     config = parse_project_config(root)
     if config is None:
         raise ValueError(f"Failed to parse new config at '{config_path}'.")

--- a/python/tach/mcp/project.py
+++ b/python/tach/mcp/project.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from dataclasses import asdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypedDict
+
+import tomli_w
+
+from tach.filesystem import build_project_config_path, find_project_config_root
+from tach.mcp.payloads import DEFAULT_LIMIT, digest, truncate_items
+from tach.modularity import build_modules
+from tach.parsing import combine_exclude_paths, parse_project_config
+
+if TYPE_CHECKING:
+    from tach.extension import ProjectConfig
+
+
+class DependencyRule(TypedDict):
+    path: str
+    dependency: str
+
+
+def resolve_project_root(project_root_value: str | None = None) -> Path:
+    if project_root_value:
+        return Path(project_root_value).expanduser().resolve()
+    return find_project_config_root() or Path.cwd().resolve()
+
+
+def project_ref(project_root_value: str | Path) -> str:
+    return urlsafe_b64encode(
+        str(Path(project_root_value).expanduser().resolve()).encode()
+    ).decode()
+
+
+def project_root_from_ref(project_ref_value: str) -> Path:
+    return Path(urlsafe_b64decode(project_ref_value.encode()).decode()).resolve()
+
+
+def resolve_project_path(root: Path, path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    return candidate.resolve()
+
+
+def rel_project_path(root: Path, path: str | Path) -> Path:
+    return resolve_project_path(root, path).relative_to(root)
+
+
+def resource_uris(root: Path) -> dict[str, str]:
+    ref = project_ref(root)
+    return {
+        "config": f"tach://project-config/{ref}",
+        "summary": f"tach://project-summary/{ref}",
+        "graph": f"tach://project-graph/{ref}",
+        "dependency_map": f"tach://dependency-map/{ref}?view=summary",
+        "modularity_report": f"tach://modularity-report/{ref}?view=summary",
+        "delta": f"tach://delta/{ref}/main",
+    }
+
+
+def missing_config_result(mode: str, root: Path) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "mode": mode,
+        "project_root": str(root),
+        "error": f"No Tach config found below '{root}'.",
+        "next_action": "Call tach_onboard, then tach_configure action='create_config'.",
+    }
+
+
+def default_python_file(root: Path, config: ProjectConfig) -> str | None:
+    for source_root in config.source_roots:
+        absolute_root = resolve_project_path(root, source_root)
+        if not absolute_root.exists():
+            continue
+        for candidate in sorted(absolute_root.rglob("*.py")):
+            if "__pycache__" not in candidate.parts:
+                return str(candidate.relative_to(root))
+    return None
+
+
+def project_config(
+    root: Path,
+    exclude: list[str] | None = None,
+) -> ProjectConfig:
+    config = parse_project_config(root)
+    if config is None:
+        raise ValueError(f"No Tach config found below '{root}'.")
+    config.exclude = combine_exclude_paths(exclude, config.exclude)
+    return config
+
+
+def config_summary(config: ProjectConfig) -> dict[str, Any]:
+    modules = build_modules(config)
+    return {
+        "source_roots": [str(root) for root in config.source_roots],
+        "modules": [asdict(module) for module in modules],
+        "interfaces": [
+            {
+                "expose": interface.expose,
+                "from_modules": interface.from_modules,
+                "visibility": interface.visibility,
+                "data_types": interface.data_types,
+            }
+            for interface in config.all_interfaces()
+        ],
+        "utility_paths": config.utility_paths(),
+        "module_paths": config.module_paths(),
+        "exclude": config.exclude,
+        "exact": config.exact,
+        "root_module": config.root_module,
+        "forbid_circular_dependencies": config.forbid_circular_dependencies,
+    }
+
+
+def compact_config_summary(
+    root: Path,
+    config: ProjectConfig,
+    *,
+    limit: int = DEFAULT_LIMIT,
+    offset: int = 0,
+) -> dict[str, Any]:
+    full = config_summary(config)
+    module_paths = list(full["module_paths"])
+    ref = project_ref(root)
+    return {
+        "project_root": str(root),
+        "source_roots": full["source_roots"],
+        "module_count": len(module_paths),
+        "interface_count": len(full["interfaces"]),
+        "utility_count": len(full["utility_paths"]),
+        "dependency_count": sum(
+            len(module.get("depends_on", [])) for module in full["modules"]
+        ),
+        "exact": full["exact"],
+        "root_module": full["root_module"],
+        "forbid_circular_dependencies": full["forbid_circular_dependencies"],
+        "digest": digest(full),
+        "resource_uri": f"tach://project-config/{ref}",
+        "summary_resource_uri": f"tach://project-summary/{ref}",
+        "modules": truncate_items(module_paths, limit=limit, offset=offset),
+        "truncated": offset + max(0, limit) < len(module_paths),
+    }
+
+
+def save_config(
+    root: Path,
+    source_roots: list[str],
+    modules: list[str],
+    utilities: list[str] | None = None,
+    dependencies: list[DependencyRule] | None = None,
+) -> ProjectConfig:
+    config_path = build_project_config_path(root)
+    module_data: list[dict[str, Any]] = [
+        {"path": module, "depends_on": []} for module in modules
+    ]
+    for module in modules:
+        if utilities and module in utilities:
+            next(item for item in module_data if item["path"] == module)["utility"] = (
+                True
+            )
+    for utility in sorted(set(utilities or []) - set(modules)):
+        module_data.append({"path": utility, "depends_on": [], "utility": True})
+    for dependency in dependencies or []:
+        module = next(
+            item for item in module_data if item["path"] == dependency["path"]
+        )
+        module["depends_on"].append({"path": dependency["dependency"]})
+    config_path.write_text(
+        tomli_w.dumps({"source_roots": source_roots, "modules": module_data})
+    )
+    config = parse_project_config(root)
+    if config is None:
+        raise ValueError(f"Failed to parse new config at '{config_path}'.")
+    return config

--- a/python/tach/mcp/reporting.py
+++ b/python/tach/mcp/reporting.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tach.mcp.project import (
+    default_python_file,
+    missing_config_result,
+    resolve_project_path,
+    resolve_project_root,
+)
+from tach.mcp.server import mcp
+from tach.parsing import parse_project_config
+from tach.report import external_dependency_report, report
+
+
+@mcp.tool()
+def tach_report(
+    path: str | None = None,
+    project_root: str | None = None,
+    external: bool = False,
+    dependencies: bool = True,
+    usages: bool = True,
+    raw: bool = False,
+    dependency_modules: list[str] | None = None,
+    usage_modules: list[str] | None = None,
+) -> dict[str, Any]:
+    """Generate Tach dependency, usage, and optional external dependency report."""
+    root = resolve_project_root(project_root)
+    config = parse_project_config(root)
+    if config is None:
+        return missing_config_result("report", root)
+    if path is None:
+        path = default_python_file(root, config)
+    if path is None:
+        return {
+            "ok": False,
+            "mode": "report",
+            "error": "path is required, and no module or Python file was found.",
+        }
+    target = resolve_project_path(root, path)
+    reports: list[str] = []
+    if dependencies or usages:
+        reports.append(
+            report(
+                root,
+                target,
+                project_config=config,
+                include_dependency_modules=dependency_modules,
+                include_usage_modules=usage_modules,
+                skip_dependencies=not dependencies,
+                skip_usages=not usages,
+                raw=raw,
+            )
+        )
+    if external:
+        reports.append(
+            external_dependency_report(root, target, project_config=config, raw=raw)
+        )
+    return {"mode": "report", "path": str(target), "report": "\n".join(reports)}

--- a/python/tach/mcp/reporting.py
+++ b/python/tach/mcp/reporting.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from tach.mcp.payloads import DEFAULT_MAX_BYTES, tail_text
 from tach.mcp.project import (
     default_python_file,
     missing_config_result,
@@ -23,6 +24,7 @@ def tach_report(
     raw: bool = False,
     dependency_modules: list[str] | None = None,
     usage_modules: list[str] | None = None,
+    max_bytes: int = DEFAULT_MAX_BYTES,
 ) -> dict[str, Any]:
     """Generate Tach dependency, usage, and optional external dependency report."""
     root = resolve_project_root(project_root)
@@ -56,4 +58,11 @@ def tach_report(
         reports.append(
             external_dependency_report(root, target, project_config=config, raw=raw)
         )
-    return {"mode": "report", "path": str(target), "report": "\n".join(reports)}
+    tail = tail_text("\n".join(reports), max_bytes=max_bytes)
+    return {
+        "mode": "report",
+        "path": str(target),
+        "report": tail["text"],
+        "report_bytes": tail["bytes"],
+        "report_truncated": tail["truncated"],
+    }

--- a/python/tach/mcp/server.py
+++ b/python/tach/mcp/server.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+MCP_PROTOCOL_VERSION = "2025-11-25"
+DEFAULT_LIMIT = 50
+DEFAULT_MAX_BYTES = 12_000
+
+mcp = FastMCP(
+    "tach",
+    instructions=(
+        "Use Tach to inspect and maintain Python module boundaries, dependency "
+        "rules, public interfaces, dependency maps, reports, and affected-test scope."
+    ),
+)
+
+
+def run() -> None:
+    """Run Tach MCP server over stdio."""
+    mcp.run()
+
+
+__all__ = ["DEFAULT_LIMIT", "DEFAULT_MAX_BYTES", "MCP_PROTOCOL_VERSION", "mcp", "run"]

--- a/python/tach/mcp/testing.py
+++ b/python/tach/mcp/testing.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from typing import Any
+
+from tach.mcp.payloads import DEFAULT_MAX_BYTES, tail_text
+from tach.mcp.project import project_config, resolve_project_root
+from tach.mcp.server import mcp
+from tach.test import run_affected_tests
+
+
+@mcp.tool()
+def tach_test(
+    project_root: str | None = None,
+    base: str = "main",
+    head: str = "",
+    pytest_args: list[str] | str | None = None,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> dict[str, Any]:
+    """Run pytest with Tach affected-test filtering and compact output tails."""
+    root = resolve_project_root(project_root)
+    config = project_config(root)
+    normalized_pytest_args = (
+        pytest_args.split() if isinstance(pytest_args, str) else pytest_args or []
+    )
+    stdout_buffer = StringIO()
+    stderr_buffer = StringIO()
+    with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+        result = run_affected_tests(
+            project_root=root,
+            project_config=config,
+            head=head,
+            base=base,
+            pytest_args=normalized_pytest_args,
+        )
+    stdout = result.stdout or stdout_buffer.getvalue()
+    stderr = result.stderr or stderr_buffer.getvalue()
+    stdout_tail = tail_text(stdout, max_bytes=max_bytes)
+    stderr_tail = tail_text(stderr, max_bytes=max_bytes)
+    return {
+        "ok": result.exit_code == 0,
+        "exit_code": result.exit_code,
+        "tests_ran_to_completion": result.tests_ran_to_completion,
+        "stdout_tail": stdout_tail["text"],
+        "stdout_bytes": stdout_tail["bytes"],
+        "stdout_truncated": stdout_tail["truncated"],
+        "stderr_tail": stderr_tail["text"],
+        "stderr_bytes": stderr_tail["bytes"],
+        "stderr_truncated": stderr_tail["truncated"],
+    }

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tach import mcp as tach_mcp
+
+EXAMPLE_ROOT = Path(__file__).parent / "example" / "valid"
+
+
+def test_tach_mcp_onboard_summary():
+    result = tach_mcp.tach_onboard(str(EXAMPLE_ROOT))
+
+    assert result["mcp_protocol"] == tach_mcp.MCP_PROTOCOL_VERSION
+    assert result["configured"] is True
+    assert result["project"]["module_count"] == 4
+    assert result["resources"]["config"].startswith("tach://project-config/")
+
+
+def test_tach_mcp_onboard_unconfigured(tmp_path):
+    result = tach_mcp.tach_onboard(str(tmp_path), intent="bootstrap")
+
+    assert result["configured"] is False
+    assert "tach_configure" in result["next_actions"][0]
+
+
+def test_tach_mcp_configure_project(tmp_path):
+    project_root = tmp_path / "project"
+    src = project_root / "src"
+    src.mkdir(parents=True)
+    (src / "module_one.py").write_text("import module_two\n")
+    (src / "module_two.py").write_text("")
+    (src / "module_three.py").write_text("")
+
+    created = tach_mcp.tach_configure(
+        "create_config",
+        str(project_root),
+        source_roots=["src"],
+        modules=["module_one", "module_two"],
+        utilities=["module_two"],
+        dependencies=[{"path": "module_one", "dependency": "module_two"}],
+    )
+    assert created["ok"] is True
+    assert (project_root / "tach.toml").exists()
+
+    edited = tach_mcp.tach_configure(
+        "edit_dependency",
+        str(project_root),
+        path="module_one",
+        dependency="module_two",
+        dependency_action="remove",
+    )
+    assert edited["ok"] is True
+
+    module_edited = tach_mcp.tach_configure(
+        "edit_module",
+        str(project_root),
+        path="module_three",
+        module_action="create",
+        include_config=True,
+    )
+    assert "module_three" in module_edited["config"]["module_paths"]
+
+
+def test_tach_mcp_lint_defaults_to_strong_checks():
+    result = tach_mcp.tach_lint(str(EXAMPLE_ROOT))
+
+    assert result["ok"] is True
+    assert result["checks"] == ["boundaries", "external", "unused"]
+    assert result["warning_count"] == 1
+    assert result["boundaries"]["diagnostics"]["items"][0]["severity"] == "warning"
+
+
+def test_tach_mcp_analyze_imports_and_report():
+    imports = tach_mcp.tach_imports(
+        path="domain_one/__init__.py",
+        project_root=str(EXAMPLE_ROOT),
+    )
+    assert imports["imports"][0]["module_path"] == "domain_two.x"
+
+    report = tach_mcp.tach_report(path="domain_two", project_root=str(EXAMPLE_ROOT))
+    assert report["mode"] == "report"
+    assert "report" in report
+
+
+def test_tach_mcp_analyze_graph_and_dependency_map():
+    graph = tach_mcp.tach_graph(str(EXAMPLE_ROOT))
+
+    assert graph["graph_preview"].startswith("graph TD")
+    assert "resource_uri" in graph
+
+    dep_map = tach_mcp.tach_map(str(EXAMPLE_ROOT), limit=1)
+    assert dep_map["file_count"] > 1
+    assert dep_map["entries"]["truncated"] is True
+    assert "map" not in dep_map
+
+
+def test_tach_mcp_analyze_closure_delta_and_changed_files():
+    closure = tach_mcp.tach_map(
+        str(EXAMPLE_ROOT),
+        mode="closure",
+        path="domain_two/some_file.py",
+    )
+    assert "domain_two/some_file.py" in closure["closure"]
+
+    delta = tach_mcp.tach_map(
+        str(EXAMPLE_ROOT),
+        mode="delta",
+        changed=["domain_two/other.py"],
+    )
+    assert delta["changed_files"] == ["domain_two/other.py"]
+    assert "domain_two/some_file.py" in delta["affected"]["items"]
+
+
+def test_tach_mcp_analyze_modularity_export(tmp_path):
+    summary = tach_mcp.tach_modularity(str(Path.cwd()), force=True)
+    assert summary["module_count"] > 1
+    assert "full_configuration" not in summary
+
+    output_path = tmp_path / "report.json"
+    exported = tach_mcp.tach_modularity(
+        str(Path.cwd()),
+        mode="export",
+        output_path=str(output_path),
+        force=True,
+    )
+    assert exported["ok"] is True
+    assert json.loads(output_path.read_text())["repo"] == "tach"
+
+
+def test_tach_mcp_test_affected():
+    result = tach_mcp.tach_test(
+        str(Path.cwd()),
+        pytest_args=["python/tests/test_cli.py", "-q"],
+        max_bytes=1000,
+    )
+
+    assert result["ok"] is True
+    assert result["stdout_bytes"] > 0
+
+
+def test_tach_mcp_prompts():
+    prompt = tach_mcp.diagnose_tach_boundaries(str(EXAMPLE_ROOT))
+
+    assert "tach_lint" in prompt

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -139,6 +139,100 @@ def test_tach_mcp_test_affected():
     assert result["stdout_bytes"] > 0
 
 
+def test_tach_mcp_create_config_emits_editable_format(tmp_path):
+    # The Rust config editor (sync_project/save_edits) silently no-ops on
+    # inline `modules = [{...}]` arrays, so generated configs must use
+    # [[modules]] array-of-tables format.
+    project_root = tmp_path / "project"
+    src = project_root / "src"
+    src.mkdir(parents=True)
+    (src / "module_one.py").write_text("import module_two\n")
+    (src / "module_two.py").write_text("")
+
+    tach_mcp.tach_configure(
+        "create_config",
+        str(project_root),
+        source_roots=["src"],
+        modules=["module_one", "module_two"],
+    )
+    assert "[[modules]]" in (project_root / "tach.toml").read_text()
+
+    synced = tach_mcp.tach_configure("sync_dependencies", str(project_root))
+    assert synced["changed"] is True
+    assert 'depends_on = ["module_two"]' in (project_root / "tach.toml").read_text()
+
+
+def test_tach_mcp_configure_architecture_rules(tmp_path):
+    project_root = tmp_path / "project"
+    src = project_root / "src"
+    src.mkdir(parents=True)
+    (src / "api.py").write_text("import services\n")
+    (src / "services.py").write_text("import models\n")
+    (src / "models.py").write_text("")
+
+    tach_mcp.tach_configure(
+        "create_config",
+        str(project_root),
+        source_roots=["src"],
+        modules=["api", "services", "models"],
+        dependencies=[
+            {"path": "api", "dependency": "services"},
+            {"path": "services", "dependency": "models"},
+        ],
+    )
+
+    layered = tach_mcp.tach_configure(
+        "set_layers",
+        str(project_root),
+        layers=["ui", "commands", "core"],
+    )
+    assert layered["ok"] is True
+    tach_mcp.tach_configure(
+        "set_module_layer", str(project_root), path="api", layer="ui"
+    )
+    visible = tach_mcp.tach_configure(
+        "set_module_visibility",
+        str(project_root),
+        path="models",
+        visibility=["services"],
+    )
+    assert visible["ok"] is True
+
+    deprecated = tach_mcp.tach_configure(
+        "deprecate_dependency",
+        str(project_root),
+        path="services",
+        dependency="models",
+    )
+    assert deprecated["deprecated"] is True
+
+    added = tach_mcp.tach_configure(
+        "add_interface",
+        str(project_root),
+        interface_expose=["get_model"],
+        interface_from=["models"],
+        interface_data_types="primitive",
+    )
+    assert added["ok"] is True
+
+    config_text = (project_root / "tach.toml").read_text()
+    assert 'layers = [\n    "ui",' in config_text
+    assert 'layer = "ui"' in config_text
+    assert "deprecated = true" in config_text
+    assert "[[interfaces]]" in config_text
+
+    lint = tach_mcp.tach_lint(str(project_root), checks="boundaries")
+    assert lint["warning_count"] == 1  # deprecated services -> models usage
+
+    removed = tach_mcp.tach_configure(
+        "remove_interface",
+        str(project_root),
+        interface_expose=["get_model"],
+        interface_from=["models"],
+    )
+    assert removed["removed"] == 1
+
+
 def test_tach_mcp_lint_reports_circular_dependencies_structured(tmp_path):
     project_root = tmp_path / "project"
     src = project_root / "src"

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -139,6 +139,49 @@ def test_tach_mcp_test_affected():
     assert result["stdout_bytes"] > 0
 
 
+def test_tach_mcp_lint_reports_circular_dependencies_structured(tmp_path):
+    project_root = tmp_path / "project"
+    src = project_root / "src"
+    src.mkdir(parents=True)
+    (src / "module_one.py").write_text("import module_two\n")
+    (src / "module_two.py").write_text("import module_one\n")
+
+    tach_mcp.tach_configure(
+        "create_config",
+        str(project_root),
+        source_roots=["src"],
+        modules=["module_one", "module_two"],
+        dependencies=[
+            {"path": "module_one", "dependency": "module_two"},
+            {"path": "module_two", "dependency": "module_one"},
+        ],
+        forbid_circular_dependencies=True,
+    )
+    assert (
+        "forbid_circular_dependencies = true"
+        in (project_root / "tach.toml").read_text()
+    )
+
+    result = tach_mcp.tach_lint(str(project_root), checks="boundaries")
+
+    assert result["ok"] is False
+    assert result["boundaries"]["ok"] is False
+    assert "module_one" in result["boundaries"]["circular_dependencies"]
+    assert result["next_actions"]
+
+
+def test_tach_mcp_report_is_size_bounded():
+    result = tach_mcp.tach_report(
+        path="domain_two",
+        project_root=str(EXAMPLE_ROOT),
+        max_bytes=50,
+    )
+
+    assert result["report_truncated"] is True
+    assert len(result["report"].encode()) <= 50
+    assert result["report_bytes"] > 50
+
+
 def test_tach_mcp_prompts():
     prompt = tach_mcp.diagnose_tach_boundaries(str(EXAMPLE_ROOT))
 

--- a/skills/tach/SKILL.md
+++ b/skills/tach/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: tach
+description: Enforce and fix Python module boundaries with the Tach MCP server. Use when a repo contains tach.toml, when import/dependency violations are reported, or when asked to modularize a Python codebase. Drives tach_onboard, tach_lint, tach_configure, tach_report, tach_map, tach_graph, and tach_test efficiently.
+---
+
+# Tach: module boundary enforcement
+
+Tach enforces declared dependencies, public interfaces, and acyclicity between
+Python modules. This skill drives the `tach` MCP server (configure the client
+to run `tach mcp`; see docs/usage/commands.md).
+
+## Workflow
+
+1. **Always start with `tach_onboard`.** It returns whether the project is
+   configured, a compact summary, and the exact next actions. Never guess
+   project state.
+2. **Unconfigured repo**: call `tach_configure action="create_config"` with
+   `source_roots`, `modules` (top-level packages), intended `dependencies`,
+   and `forbid_circular_dependencies=true` for new projects. Then
+   `tach_configure action="sync_dependencies"` to align rules with reality.
+3. **Check**: `tach_lint` runs boundary, interface, external, and unused
+   dependency checks in one call. Read `error_count` first; diagnostics are
+   paginated (`limit`/`offset`) — page through only when fixing.
+4. **Diagnose a violation**: `tach_report` with the failing file shows its
+   dependencies and usages. `tach_map mode="closure"` shows everything a file
+   pulls in; `tach_map mode="delta"` scopes the blast radius of changed files
+   before large edits.
+5. **Fix**: either move the import to respect the declared direction, or — if
+   the architecture genuinely changed — `tach_configure
+   action="edit_dependency"` to update the rules. Prefer fixing code over
+   loosening rules.
+6. **Verify**: re-run `tach_lint`, then `tach_test` (affected tests only) to
+   confirm nothing broke.
+
+## Token discipline
+
+- Default modes are compact and paginated; stay on them. Use `view="full"`,
+  `mode="full"`, or `include_full=true` only when you must read an entire
+  payload, and prefer the `tach://...` resource URIs for bulk data.
+- `tach_lint`, `tach_report`, `tach_graph`, and `tach_test` accept
+  `limit`/`offset` or `max_bytes` — lower them when triaging large repos.
+
+## Interpreting results
+
+- `boundaries.circular_dependencies` (list of module paths) means the declared
+  dependency graph has a cycle: remove one edge with
+  `tach_configure action="edit_dependency", dependency_action="remove"`.
+- Many identical diagnostics against one module usually mean a utility/god
+  module: mark it with `tach_configure action="edit_module",
+  module_action="mark_utility"` only if it is genuinely interface-free shared
+  code; otherwise split it.
+- `unused.unused_dependencies` are declared edges no code uses — remove them
+  with `sync_dependencies` or `edit_dependency`.
+
+## Hooks
+
+If a `PostToolUse` hook runs `tach check` after edits, a non-zero hook result
+quoting boundary diagnostics is authoritative — fix the violation before
+moving on instead of retrying the edit. Outside hook-enabled environments,
+`tach_configure action="install_pre_commit"` gives the same guarantee at
+commit time.

--- a/skills/tach/SKILL.md
+++ b/skills/tach/SKILL.md
@@ -28,8 +28,16 @@ to run `tach mcp`; see docs/usage/commands.md).
 5. **Fix**: either move the import to respect the declared direction, or — if
    the architecture genuinely changed — `tach_configure
    action="edit_dependency"` to update the rules. Prefer fixing code over
-   loosening rules.
-6. **Verify**: re-run `tach_lint`, then `tach_test` (affected tests only) to
+   loosening rules. For a violation that must stay temporarily, add a
+   `# tach-ignore(reason)` comment on the import line instead of deleting the
+   rule — unused or reason-less directives are themselves lintable.
+6. **Architecture rules**: `tach_configure` also writes the higher-level
+   constraints — `action="set_layers"` (ordered layer list, optionally
+   `layers_explicit_depends_on`), `"set_module_layer"`,
+   `"set_module_visibility"`, `"add_interface"` / `"remove_interface"`
+   (public interface per module), and `"deprecate_dependency"` (keep an edge
+   legal but warn on use while migrating off it).
+7. **Verify**: re-run `tach_lint`, then `tach_test` (affected tests only) to
    confirm nothing broke.
 
 ## Token discipline

--- a/tach.toml
+++ b/tach.toml
@@ -171,6 +171,7 @@ layer = "commands"
 [[modules]]
 path = "tach.mcp.reporting"
 depends_on = [
+    "tach.mcp.payloads",
     "tach.mcp.project",
     "tach.mcp.server",
     "tach.report",

--- a/tach.toml
+++ b/tach.toml
@@ -98,6 +98,125 @@ depends_on = [
 layer = "core"
 
 [[modules]]
+path = "tach.mcp"
+depends_on = [
+    "tach.mcp.configuration",
+    "tach.mcp.dependency_map",
+    "tach.mcp.imports",
+    "tach.mcp.linting",
+    "tach.mcp.modularity",
+    "tach.mcp.module_graph",
+    "tach.mcp.onboarding",
+    "tach.mcp.reporting",
+    "tach.mcp.server",
+    "tach.mcp.testing",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.server"
+depends_on = []
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.payloads"
+depends_on = []
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.project"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.modularity",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.onboarding"
+depends_on = [
+    "tach",
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.configuration"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.linting"
+depends_on = [
+    "tach.check_external",
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.imports"
+depends_on = [
+    "tach.mcp.project",
+    "tach.mcp.server",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.reporting"
+depends_on = [
+    "tach.mcp.project",
+    "tach.mcp.server",
+    "tach.report",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.dependency_map"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.module_graph"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+    "tach.show",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.modularity"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+    "tach.modularity",
+]
+layer = "commands"
+
+[[modules]]
+path = "tach.mcp.testing"
+depends_on = [
+    "tach.mcp.payloads",
+    "tach.mcp.project",
+    "tach.mcp.server",
+    "tach.test",
+]
+layer = "commands"
+
+[[modules]]
 path = "tach.parsing"
 depends_on = [
     "tach.extension",
@@ -144,6 +263,7 @@ expose = [
     "Module",
     "Usage",
     "build_.*",
+    "generate_modularity_report",
     "serialize_.*",
 ]
 from = [

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,29 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -441,37 +464,54 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
     { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
     { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
     { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
     { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
     { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
     { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
     { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
     { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
     { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
     { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
     { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
     { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
     { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
     { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
     { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
     { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
     { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
     { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
     { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
     { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
     { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
     { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
     { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
     { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
     { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
     { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
     { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
     { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
 ]
 
 [[package]]
@@ -604,6 +644,52 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -709,6 +795,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -857,6 +970,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/c6/cbf8a51dde19c19aeba0d9b075095a2effb9b31fd312b1aae3ac79f8aea2/maturin-1.13.3-py3-none-win32.whl", hash = "sha256:0ef257e692cc756c87af5bea95ddfe7d3ac49d3376a7a87f728d63f06e7b6f8b", size = 8901838, upload-time = "2026-05-11T07:43:23.76Z" },
     { url = "https://files.pythonhosted.org/packages/a1/ff/c6a50a59dc8313097d43ac5f4d74df6a500c8cb62b0dc9e054f53e203a48/maturin-1.13.3-py3-none-win_amd64.whl", hash = "sha256:def4a435ea9d2ee93b18ba579dc8c9cf898889a66f312cd379b5e374ec3e3ad6", size = 10340801, upload-time = "2026-05-11T07:43:29.239Z" },
     { url = "https://files.pythonhosted.org/packages/6c/93/e32e79333f0902ba292b996f504f5f06be59587f7d02ab8d5ed1e3066445/maturin-1.13.3-py3-none-win_arm64.whl", hash = "sha256:2389fe92d017cea9d94e521fa0175314a4c52f79a1057b901fbc9f8686ef7d0b", size = 9706562, upload-time = "2026-05-11T07:43:31.743Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -1138,6 +1276,151 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
 name = "pydot"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1165,6 +1448,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/16/3f/f286caba4e64391a8dc9200e6de6ce0d07471e3f718248c3276843b7793b/pyhamcrest-2.1.0.tar.gz", hash = "sha256:c6acbec0923d0cb7e72c22af1926f3e7c97b8e8d69fc7498eabacaf7c975bd9c", size = 60538, upload-time = "2023-10-22T15:47:28.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/71/1b25d3797a24add00f6f8c1bb0ac03a38616e2ec6606f598c1d50b0b0ffb/pyhamcrest-2.1.0-py3-none-any.whl", hash = "sha256:f6913d2f392e30e0375b3ecbd7aee79e5d1faa25d345c8f4ff597665dcac2587", size = 54555, upload-time = "2023-10-22T15:47:25.08Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1242,6 +1542,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
 name = "python-jsonrpc-server"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,6 +1560,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/7d/c4c4102b94ef2e090d94fc02625653d3d3a0306e53ef24bcb6e9496bfc1e/python-jsonrpc-server-0.4.0.tar.gz", hash = "sha256:62c543e541f101ec5b57dc654efc212d2c2e3ea47ff6f54b2e7dcb36ecf20595", size = 26491, upload-time = "2020-09-08T19:22:46.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/4c/fa4be41bfc1aa933fe9f9990472dfbbe14527b8864c8a722df0799258966/python_jsonrpc_server-0.4.0-py3-none-any.whl", hash = "sha256:e5a908ff182e620aac07db5f57887eeb0afe33993008f57dc1b85b594cea250c", size = 8947, upload-time = "2020-09-08T19:22:48.17Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -1341,6 +1681,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1387,6 +1741,128 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1467,11 +1943,38 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+]
+
+[[package]]
 name = "tach"
 version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },
+    { name = "mcp" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "prompt-toolkit" },
@@ -1513,6 +2016,7 @@ vscode = [
 [package.metadata]
 requires-dist = [
     { name = "gitpython", specifier = "~=3.1" },
+    { name = "mcp", specifier = ">=1.27.1" },
     { name = "networkx", specifier = ">=2.6,<4.0" },
     { name = "prompt-toolkit", specifier = "~=3.0" },
     { name = "pydot", specifier = ">=2,<5" },
@@ -1655,6 +2159,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
 name = "ujson"
 version = "5.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1746,6 +2262,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds a `tach mcp` subcommand that runs Tach as a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server over stdio. MCP-compatible agents — Claude Code, Claude Desktop, Codex CLI, and others — can inspect, lint, configure, and report on Tach projects through a small set of compact, paginated tools instead of shelling out to individual CLI commands and parsing rendered text.

Everything outside the new `python/tach/mcp/` package is strictly additive: the subcommand registration in `cli.py`, the `mcp` dependency in `pyproject.toml`, module declarations plus one interface expose in `tach.toml`, the docs, and an optional agent skill file. No existing behavior is modified, and there are no Rust changes.

We built this because we use Tach with coding agents daily, and the CLI surface is awkward for them in two ways: rendered text output has to be re-parsed, and full outputs (dependency maps, long check runs) blow through context budgets. The design below is the result of benchmarking real agent sessions against both a synthetic project and a fresh Django clone — numbers included, with a reproducible script.

## What's included

### The `tach mcp` command

```bash
tach mcp
```

Starts a FastMCP stdio server. Client configuration examples for JSON-based clients (Claude Desktop/Code) and TOML-based clients (Codex CLI) are included in `docs/usage/commands.md`.

### Nine tools, designed for agent workflows rather than a 1:1 CLI mirror

| Tool | Purpose | Backing functionality |
|---|---|---|
| `tach_onboard` | Entry point: versions, configured state, compact project summary, recommended next actions | `parse_project_config`, summaries |
| `tach_lint` | One strong lint call: boundaries + interfaces + external deps + unused deps, with counts and paginated diagnostics | `check`, `check_external`, `detect_unused_dependencies` |
| `tach_configure` | The single controlled write tool — covers the full config surface (details below) | config edit APIs + TOML editing |
| `tach_imports` | First-party or external imports Tach sees in one file | `get_project_imports` / `get_external_imports` |
| `tach_report` | Dependency/usage/external report for a path, byte-bounded | `report`, `external_dependency_report` |
| `tach_map` | Dependency map summary/full, closure, changed files, and an agent-oriented `delta` mode (blast radius of a change set) | `DependentMap` |
| `tach_graph` | Module graph as Mermaid or DOT, preview-capped by default | `generate_module_graph_*` |
| `tach_modularity` | Local modularity report summary/full/export | `generate_modularity_report`, `export_report` |
| `tach_test` | Affected-test run with compact stdout/stderr tails | `run_affected_tests` |

`tach_configure` actions: `create_config` (incl. `forbid_circular_dependencies`), `edit_module`, `edit_dependency`, `sync_dependencies`, `set_layers` (+ `layers_explicit_depends_on`), `set_module_layer`, `set_module_visibility`, `add_interface` / `remove_interface`, `deprecate_dependency` / `undeprecate_dependency`, and `install_pre_commit`. This means MCP-only clients with no filesystem access can manage boundaries end to end, including the higher-level architecture rules.

The server also exposes nine resource endpoints across seven URI families
(`tach://version`, `tach://project-config/...`, `tach://project-summary/...`,
`tach://project-graph/...`, `tach://dependency-map/...` with a `?view=` variant,
`tach://modularity-report/...` with a `?view=` variant, and `tach://delta/...`)
for opt-in bulk payloads, and two prompts (`diagnose_tach_boundaries`,
`plan_tach_modularization`).


### Token discipline as a design rule

Every default response is summary-first: counts, digests, paginated items (`limit`/`offset`), byte-capped text tails (`max_bytes`, default 12 KB), and resource URIs pointing at the full payloads. Full views exist but are always explicit (`view="full"`, `mode="full"`, `include_full=true`).

Errors are structured too: with `forbid_circular_dependencies = true`, a config cycle comes back as `boundaries.circular_dependencies` (the module list) plus a `next_actions` hint, mirroring the CLI's handling of `TachCircularDependencyError` / `TachVisibilityError` rather than surfacing a bare exception.

### Benchmark (reproducible)

Measured over a real MCP stdio session (official `mcp` Python client; byte counts are exact wire JSON) against a fresh Django shallow clone — 2,126 resolved first-party files, 9,534 file-level edges, 14 declared modules:

| Query | Default response | Naive alternative | Savings |
|---|---|---|---|
| Dependency map | 5.8 KB (~1.4K tokens) | 520.7 KB full map (~130K tokens) | **90x** |
| Project summary | 2.5 KB | 14.0 KB full config view | 5.5x |
| 386 lint diagnostics | 19.8 KB first page (5.2 KB at `limit=10`) | ~150 KB unpaginated | 8–29x |
| Blast radius of one ORM file | 2.9 KB conveying 2,078 affected files | reading the full closure | — |

`sync_dependencies` wrote 90 module edges in 2.8 s end-to-end; all write actions completed in <0.6 s with ~250 B responses. Methodology and a standalone driver script live in `docs/usage/mcp-benchmark.md` so these claims are independently verifiable.

### Agent skill and docs

- `skills/tach/SKILL.md` — an [Agent Skill](https://agentskills.io) (the cross-tool `SKILL.md` format supported by Claude Code, Codex CLI, and others) that teaches agents the efficient workflow: onboard first, stay on compact modes, diagnose with report/map, prefer fixing code (or `# tach-ignore(reason)`) over loosening rules, verify with lint + test. Nothing is installed implicitly — the docs show one-line copy commands per tool.
- `docs/usage/commands.md` — full `tach mcp` section: client setup, all tools/resources/prompts, example workflows, skill install, and an optional Claude Code `PostToolUse` hook that feeds `tach check` diagnostics straight back to an editing agent.
- `docs/usage/mcp-benchmark.md` — benchmark methodology + reproduction script (added to the mkdocs nav).
- `README.md` — a short "AI agents (MCP server)" section.

## Bug found while benchmarking (worth a look even if this PR isn't merged)

The Rust config editor silently no-ops on configs that declare modules as an inline array. `apply_edits` in `src/config/project.rs` only matches `toml_edit::Item::ArrayOfTables` for `modules`; an inline `modules = [{ path = "..." }]` array is `Item::Value(Value::Array)` and falls through without an error — so `tach sync`, `add_dependency`, and `save_edits` all report success while writing nothing. Notably, `dump_project_config_to_toml` itself emits that inline format, and `tach mod` writes its output directly to `tach.toml` (`python/tach/mod.py`: `config_toml_content = dump_project_config_to_toml(...)`) — so the documented CLI flow `tach mod` followed by `tach sync` reproduces the silent no-op without MCP involved. The MCP layer works around it by always emitting `[[modules]]` / `[[interfaces]]` array-of-tables (with a regression test), but a Rust-side fix in `apply_edits` would cover the CLI path too. Happy to file this as a separate issue if you prefer.

## Module declarations — dogfooding

The new package is split per capability (`onboarding`, `linting`, `configuration`, `imports`, `reporting`, `dependency_map`, `module_graph`, `modularity`, `testing`, plus shared `project`/`payloads` helpers and the `server` instance), and each slice is declared in `tach.toml` with explicit `depends_on`. `tach check` caught a missing edge during development, which felt like the right kind of proof that the layout works.

## Testing

- `python/tests/test_mcp.py`: 14 tests covering every tool against the existing example fixtures, plus regression tests for the structured circular-dependency payload, report truncation, the architecture-rule actions round-trip (layers, visibility, deprecation warnings, interface add/remove), and the editable-TOML format fix.
- Full local run of the CI gates: `ruff check` / `ruff format --check`, `pytest` (104 passed, full suite), `basedpyright` (0 errors), `tach check`, `zensical build --strict`. No Rust changes, so `cargo test` / `clippy` / `fmt` are unaffected.
- End-to-end validation: fresh-clone build + a scripted MCP stdio handshake (initialize → tools/list → tool calls), and the Django-scale session described above.

## Notes for reviewers

- The `mcp` PyPI dependency (`mcp>=1.27.1`) is the only new runtime dependency; `uv.lock` is updated accordingly.
- Tool responses deliberately return raw data structures (dicts) rather than rendered text, with one exception: `tach_report` returns the existing rendered report string (now byte-capped). If you'd prefer a structured report payload, we're glad to follow up.
- Happy to split this into smaller PRs (server core / configure write surface / docs+skill) if that's easier to review.

